### PR TITLE
Zero-initialize bookkeeping variables.

### DIFF
--- a/procgen/src/basic-abstract-game.h
+++ b/procgen/src/basic-abstract-game.h
@@ -121,15 +121,15 @@ class BasicAbstractGame : public Game {
     int last_move_action, move_action, special_action;
     float mixrate, maxspeed, max_jump;
 
-    float action_vx;
-    float action_vy;
-    float action_vrot;
+    float action_vx = 0;
+    float action_vy = 0;
+    float action_vrot = 0;
 
     float center_x, center_y;
 
     bool random_agent_start = true;
     bool has_useful_vel_info;
-    int step_rand_int;
+    int step_rand_int = 0;
 
     RandGen asset_rand_gen;
 


### PR DESCRIPTION
BasicAbstractGame maintains some bookkeeping variables that are set in a game_step. Some of these variables are also used in reset() logic, which results in an uninitialized memory access because no step has yet been performed.

* action_vx is used in CoinRun::image_for_type.
* step_random_int is used by step_entities, which is called by LeaperGame::game_reset().