### PR TITLE
Improved interactive cli by adding "advanced" switch arguments

### DIFF
--- a/procgen/interactive.py
+++ b/procgen/interactive.py
@@ -47,26 +47,80 @@ def make_interactive(vision, record_dir, **kwargs):
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--vision", choices=["agent", "human"], default="human")
+    default_str = "(default: %(default)s)"
+    parser = argparse.ArgumentParser(
+        description="Interactive version of Procgen allowing you to play the games"
+    )
+    parser.add_argument(
+        "--vision",
+        default="human",
+        choices=["agent", "human"],
+        help="level of fidelity of observation " + default_str,
+    )
     parser.add_argument("--record-dir", help="directory to record movies to")
     parser.add_argument(
         "--distribution-mode",
         default="hard",
-        help="which distribution mode to use for the level generation",
+        help="which distribution mode to use for the level generation " + default_str,
     )
     parser.add_argument(
         "--env-name",
         default="coinrun",
-        help="name of game to create",
+        help="name of game to create " + default_str,
         choices=ENV_NAMES + ["coinrun_old"],
     )
     parser.add_argument(
         "--level-seed", type=int, help="select an individual level to use"
     )
+
+    advanced_group = parser.add_argument_group("advanced optional switch arguments")
+    advanced_group.add_argument(
+        "--paint-vel-info",
+        action="store_true",
+        default=False,
+        help="paint player velocity info in the top left corner",
+    )
+    advanced_group.add_argument(
+        "--use-generated-assets",
+        action="store_true",
+        default=False,
+        help="use randomly generated assets in place of human designed assets",
+    )
+    advanced_group.add_argument(
+        "--uncenter-agent",
+        action="store_true",
+        default=False,
+        help="display the full level for games that center the observation to the agent",
+    )
+    advanced_group.add_argument(
+        "--disable-backgrounds",
+        action="store_true",
+        default=False,
+        help="disable human designed backgrounds",
+    )
+    advanced_group.add_argument(
+        "--restrict-themes",
+        action="store_true",
+        default=False,
+        help="restricts games that use multiple themes to use a single theme",
+    )
+    advanced_group.add_argument(
+        "--use-monochrome-assets",
+        action="store_true",
+        default=False,
+        help="use monochromatic rectangles instead of human designed assets",
+    )
+
     args = parser.parse_args()
 
-    kwargs = {}
+    kwargs = {
+        "paint_vel_info": args.paint_vel_info,
+        "use_generated_assets": args.use_generated_assets,
+        "center_agent": not args.uncenter_agent,
+        "use_backgrounds": not args.disable_backgrounds,
+        "restrict_themes": args.restrict_themes,
+        "use_monochrome_assets": args.use_monochrome_assets,
+    }
     if args.env_name != "coinrun_old":
         kwargs["distribution_mode"] = args.distribution_mode
     if args.level_seed is not None:


### PR DESCRIPTION
This PR improves the cli for procgen interactive by adding switch arguments for the more advanced environment options that would previously only be accessible through a traditional creation of an instance. I found that being able to try out these settings interactively is beneficial because you get a hands-on feel for how they impact the environment and observation (both in agent & human vision).

Here is how the cli help would look after this PR:

```
$ python -m procgen.interactive --help
usage: interactive.py [-h] [--vision {agent,human}] [--record-dir RECORD_DIR] [--distribution-mode DISTRIBUTION_MODE]
                      [--env-name {bigfish,bossfight,caveflyer,chaser,climber,coinrun,dodgeball,fruitbot,heist,jumper,leaper,maze,miner,ninja,plunder,starpilot,coinrun_old}] [--level-seed LEVEL_SEED] [--paint-vel-info]
                      [--use-generated-assets] [--uncenter-agent] [--disable-backgrounds] [--restrict-themes] [--use-monochrome-assets]

Interactive version of Procgen allowing you to play the games

optional arguments:
  -h, --help            show this help message and exit
  --vision {agent,human}
                        level of fidelity of observation (default: human)
  --record-dir RECORD_DIR
                        directory to record movies to
  --distribution-mode DISTRIBUTION_MODE
                        which distribution mode to use for the level generation (default: hard)
  --env-name {bigfish,bossfight,caveflyer,chaser,climber,coinrun,dodgeball,fruitbot,heist,jumper,leaper,maze,miner,ninja,plunder,starpilot,coinrun_old}
                        name of game to create (default: coinrun)
  --level-seed LEVEL_SEED
                        select an individual level to use

advanced optional switch arguments:
  --paint-vel-info      paint player velocity info in the top left corner
  --use-generated-assets
                        use randomly generated assets in place of human designed assets
  --uncenter-agent      display the full level for games that center the observation to the agent
  --disable-backgrounds
                        disable human designed backgrounds
  --restrict-themes     restricts games that use multiple themes to use a single theme
  --use-monochrome-assets
                        use monochromatic rectangles instead of human designed assets
```

Here is an example of how you would run one of these switch arguments:

```
$ python -m procgen.interactive --env-name coinrun --paint-vel-info
```

This PR has no changes that would impact training. 

Thank you for making such a great environment for evaluating learning performance.