### PR TITLE
Support for VecVideoRecorder

### DIFF
--- a/procgen/env.py
+++ b/procgen/env.py
@@ -249,7 +249,7 @@ class ProcgenGym3Env(BaseProcgenEnv):
 class ToBaselinesVecEnv(gym3.ToBaselinesVecEnv):
     metadata = {
         'render.modes': ['human', 'rgb_array'],
-        'video.frames_per_second' : 24
+        'video.frames_per_second' : 15
     }
     def render(self, mode="human"):
         info = self.env.get_info()[0]

--- a/procgen/env.py
+++ b/procgen/env.py
@@ -262,7 +262,4 @@ class ToBaselinesVecEnv(gym3.ToBaselinesVecEnv):
 
 
 def ProcgenEnv(num_envs, env_name, **kwargs):
-    """
-    Baselines VecEnv interface for Procgen
-    """
-    return gym3.ToBaselinesVecEnv(ProcgenGym3Env(num=num_envs, env_name=env_name, **kwargs))
+    return ToBaselinesVecEnv(ProcgenGym3Env(num=num_envs, env_name=env_name, **kwargs))

--- a/procgen/env.py
+++ b/procgen/env.py
@@ -244,6 +244,21 @@ class ProcgenGym3Env(BaseProcgenEnv):
                 "distribution_mode": distribution_mode,
             }
         super().__init__(num, env_name, options, **kwargs)
+        
+        
+class ToBaselinesVecEnv(gym3.ToBaselinesVecEnv):
+    metadata = {
+        'render.modes': ['human', 'rgb_array'],
+        'video.frames_per_second' : 24
+    }
+    def render(self, mode="human"):
+        info = self.env.get_info()[0]
+        _, ob, _ = self.env.observe()
+        if mode == "rgb_array":
+            if "rgb" in info:
+                return info["rgb"]
+            else:
+                return ob['rgb'][0]        
 
 
 def ProcgenEnv(num_envs, env_name, **kwargs):


### PR DESCRIPTION
Support for VecVideoRecorder
 https://stable-baselines3.readthedocs.io/en/master/guide/vec_envs.html?highlight=video#vecvideorecorder

Hello, and thank you for the amazing procedurally generated environments.

I've experienced some issues recording videos using existing libraries such as https://github.com/DLR-RM/stable-baselines3. Specifically, SB3's VecVideoRecorder can only record the video if the vectorized environment has the metadata field, which is the first piece I've added for this PR. To fully record the video, it appears one must toggle the render_mode=rgb_array, but that unfortunately significantly slows down the throughput (going from 5k SPS to 400 SPS due to the overhead of rgb arrays in the infos), as is noted in several places prescribing this method of recording. So perhaps an current solution would be to also support returning the obs's rgb array through render('rgb_array') if we want fast throughput, which is the second part of this PR.
We have tested out this approach and are able to record video during training and still keep fast throughput (see https://wandb.ai/cleanrl/cleanrl.benchmark/runs/kraizl7w as an example). It can be used in the following way

venv = ProcgenEnv(num_envs=64, env_name='starship', num_levels=0, start_level=0, distribution_mode='easy')
venv = VecExtractDictObs(venv, "rgb")
venv = VecMonitor(venv=venv)
envs = VecNormalize(venv=venv, norm_obs=False)
envs = VecPyTorch(envs, device)
envs = VecVideoRecorder(envs, f'videos', record_video_trigger=lambda x: x % 1000000== 0, video_length=100)

