### PR TITLE
use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:bionic-20191202
 RUN apt-get update && apt-get install --yes --no-install-recommends python3-pip python3-setuptools libglib2.0-0
-RUN pip3 install --upgrade pip
-RUN pip3 install procgen
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir procgen


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik raj <rajpratik71@gmail.com>