### PR TITLE
fix compilation error in #69

### DIFF
--- a/procgen/CMakeLists.txt
+++ b/procgen/CMakeLists.txt
@@ -16,7 +16,7 @@ if(APPLE)
   # clang defaults to 20 errors, but usually only the first one is useful
   add_compile_options(-ferror-limit=1)
   # only produce errors on mac where development is done
-  add_compile_options(-Werror -Wextra -Wshadow -Wall -Wformat=2 -Wundef -Wvla -Wmissing-include-dirs -Wnon-virtual-dtor -Wno-unused-parameter)
+  add_compile_options(-Werror -Wextra -Wshadow -Wall -Wformat=2 -Wundef -Wvla -Wmissing-include-dirs -Wnon-virtual-dtor -Wno-unused-parameter -Wno-unused-but-set-variable)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
Problem:
As mentioned in [this comment](https://github.com/openai/procgen/issues/69#issuecomment-1515349973) of #69, a compilation crashes due to an error of unused variables on Apple silicon (with clang 14 and possibly 13+). This issue has been reported [elsewhere](https://github.com/ClickHouse/ClickHouse/issues/27705). This seems to be caused by breaking behavior in clang 13 which escalates unused variable from a warning in prior versions to an error.

The solution implemented here:
I add an additional cflags `-Wno-unused-but-set-variable` for apple platforms. 

Tested on macOS 13.3.1 with Apple clang version 14.0.3 (clang-1403.0.22.14.1)