### PR TITLE
Fix building from source on Apple Silicon (arm64) and recent Clang

### DIFF
--- a/procgen/CMakeLists.txt
+++ b/procgen/CMakeLists.txt
@@ -26,8 +26,14 @@ endif()
 
 if (APPLE OR UNIX)
   if(PROCGEN_PACKAGE)
-    # compile for the minimum spec processor
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -march=ivybridge")
+    # compile for the minimum spec processor (for a portable wheel)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+      # -march=ivybridge is an x86-only microarch and is rejected by arm64 clang;
+      # use the base armv8-a ISA so the wheel stays portable across Apple Silicon / aarch64.
+      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -march=armv8-a")
+    else()
+      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -march=ivybridge")
+    endif()
   else()
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -march=native")
   endif()

--- a/procgen/builder.py
+++ b/procgen/builder.py
@@ -54,7 +54,11 @@ def _attempt_configure(build_type, package):
         cmake_prefix_paths = [os.environ["PROCGEN_CMAKE_PREFIX_PATH"]]
     else:
         # guess some common qt cmake paths, it's unclear why cmake can't find qt without this
-        cmake_prefix_paths = ["/usr/local/opt/qt5/lib/cmake"]
+        # (Apple Silicon Homebrew installs qt@5 under /opt/homebrew; Intel Homebrew under /usr/local)
+        cmake_prefix_paths = [
+            "/usr/local/opt/qt5/lib/cmake",
+            "/opt/homebrew/opt/qt@5/lib/cmake",
+        ]
         conda_exe = shutil.which("conda")
         if conda_exe is not None:
             conda_info = json.loads(

--- a/procgen/src/games/chaser.cpp
+++ b/procgen/src/games/chaser.cpp
@@ -293,7 +293,7 @@ class ChaserGame : public BasicAbstractGame {
     void game_step() override {
         BasicAbstractGame::game_step();
 
-        int num_orbs = 0;
+        [[maybe_unused]] int num_orbs = 0;
         int num_enemies = 0;
 
         float default_enemy_speed = .5;

--- a/procgen/src/games/starpilot.cpp
+++ b/procgen/src/games/starpilot.cpp
@@ -228,7 +228,7 @@ class StarPilotGame : public BasicAbstractGame {
 
         bool can_spawn_left = options.distribution_mode != EasyMode;
 
-        for (int i = 0; t <= SHOOTER_WIN_TIME; i++) {
+        for ([[maybe_unused]] int i = 0; t <= SHOOTER_WIN_TIME; i++) {
             int group_size = 1;
             float start_weight = rand_gen.rand01() * total_prob_weight;
             float curr_weight = start_weight;


### PR DESCRIPTION
Closes #69.


## Summary
`procgen` currently fails to **build from source on Apple Silicon (arm64)** and on recent
Xcode / AppleClang. This PR restores the source build with a small, behavior-preserving change
set. Verified end-to-end on an M1: CoinRun creates and steps, observations are the expected
`(N, 64, 64, 3)` uint8 with a 15-action discrete space.

## Root causes & fixes
1. **`-march=ivybridge` is x86-only.** `procgen/CMakeLists.txt` passes `-march=ivybridge` for
   packaged builds; that is an Intel microarchitecture and arm64 Clang rejects it outright. Guard
   it by architecture and use `-march=armv8-a` on `arm64` / `aarch64`.
2. **Qt is only probed at the Intel Homebrew path.** `procgen/builder.py` hardcodes
   `/usr/local/opt/qt5/...`. Apple Silicon Homebrew installs under `/opt/homebrew`, so also probe
   `/opt/homebrew/opt/qt@5/lib/cmake`. (`PROCGEN_CMAKE_PREFIX_PATH` still overrides everything.)
3. **Two `-Wunused-but-set-variable` warnings become errors under `-Werror`.** AppleClang 21
   promotes two `set-but-unused` locals in `starpilot.cpp` and `chaser.cpp` to hard errors. Mark
   them `[[maybe_unused]]` — no game logic changes, determinism preserved.

## Testing
Built and ran on:
- Apple M1 Max, macOS, **Python 3.12**, **AppleClang 21**, **Qt 5.15** (`brew install qt@5`).
- `ProcgenGym3Env(num=2, env_name="coinrun")` → obs `(2, 64, 64, 3)` uint8, action space `D15`,
  stepped 50× with no errors.

Build prerequisites on Apple Silicon (workflow otherwise unchanged):

```bash
brew install qt@5
pip install -e .
```

## Scope / notes
- Minimal and behavior-preserving. The `-march` change only affects packaged arm64 builds; the
  `[[maybe_unused]]` markers do not alter any game logic.
- **Out of scope (possible follow-up):** publishing prebuilt arm64 macOS wheels via the
  `cibuildwheel` matrix in `procgen-build/`. That needs arm64 CI runners and an arm64 Qt build in
  CI, which I could not validate locally. This PR restores **building from source**; a wheels PR
  can follow.

